### PR TITLE
Add optional chaining to `toc` and `footnotes` in layout.vto

### DIFF
--- a/src/_includes/layout.vto
+++ b/src/_includes/layout.vto
@@ -36,7 +36,7 @@
 
       {{ include "templates/menu.vto" }}
 
-      {{ if toc.length }}
+      {{ if toc?.length }}
       <nav class="toc">
         <h2>On this page</h2>
         <ol>
@@ -74,7 +74,7 @@
           {{ /if }}
         </div>
 
-        {{ if it.footnotes.length }}
+        {{ if it.footnotes?.length }}
         <aside role="note" class="footnotes">
           <dl>
             {{ for note of footnotes }}


### PR DESCRIPTION
Resolves #12 by adding optional chaining to `toc` and `footnotes` allowing MDX to be used.