### PR TITLE
feat: add hide_pagination option to disable page navigation

### DIFF
--- a/src/_data.yml
+++ b/src/_data.yml
@@ -1,2 +1,3 @@
 menu_links: []
 logo: # path to logo image
+hide_pagination: false # set to true to hide next/previous navigation at the bottom of pages

--- a/src/_includes/layout.vto
+++ b/src/_includes/layout.vto
@@ -167,54 +167,56 @@
         </footer>
       {{ /if }}
 
-      <nav class="body-nav pagination">
-        <ul>
+      {{ if it.hide_pagination != true }}
+        <nav class="body-nav pagination">
+          <ul>
+            {{
+              set previousPage = nav.previousPage(
+                url,
+                `lang=${lang} hide_menu!=true`,
+                "order=asc title=asc-locale basename=asc-locale",
+              )
+            }}
+
+            {{ if previousPage }}
+              <li class="pagination-prev">
+                <a href="{{ previousPage.url }}" rel="prev">
+                  ← Previous
+                  <strong>{{
+                    previousPage.title ||
+                      previousPage.basename
+                  }}</strong>
+                </a>
+              </li>
+            {{ /if }}
+
+            {{
+              set nextPage = nav.nextPage(
+                url,
+                `lang=${lang} hide_menu!=true`,
+                "order=asc title=asc-locale basename=asc-locale",
+              )
+            }}
+
+            {{ if nextPage }}
+              <li class="pagination-next">
+                <a href="{{ nextPage.url }}" rel="next">
+                  Next →
+                  <strong>{{ nextPage.title || nextPage.basename }}</strong>
+                </a>
+              </li>
+            {{ /if }}
+          </ul>
+
           {{
-            set previousPage = nav.previousPage(
+            set children = nav.menu(
               url,
               `lang=${lang} hide_menu!=true`,
               "order=asc title=asc-locale basename=asc-locale",
-            )
+            )?.children
           }}
-
-          {{ if previousPage }}
-            <li class="pagination-prev">
-              <a href="{{ previousPage.url }}" rel="prev">
-                ← Previous
-                <strong>{{
-                  previousPage.title ||
-                    previousPage.basename
-                }}</strong>
-              </a>
-            </li>
-          {{ /if }}
-
-          {{
-            set nextPage = nav.nextPage(
-              url,
-              `lang=${lang} hide_menu!=true`,
-              "order=asc title=asc-locale basename=asc-locale",
-            )
-          }}
-
-          {{ if nextPage }}
-            <li class="pagination-next">
-              <a href="{{ nextPage.url }}" rel="next">
-                Next →
-                <strong>{{ nextPage.title || nextPage.basename }}</strong>
-              </a>
-            </li>
-          {{ /if }}
-        </ul>
-
-        {{
-          set children = nav.menu(
-            url,
-            `lang=${lang} hide_menu!=true`,
-            "order=asc title=asc-locale basename=asc-locale",
-          )?.children
-        }}
-      </nav>
+        </nav>
+      {{ /if }}
     </div>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Add `hide_pagination` option to `_data.yml`
- When set to `true`, hides the next/previous page navigation at the bottom of pages
- Allows users to disable pagination without touching the layout file

Closes #3