### PR TITLE
fix: constrain media width

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -100,6 +100,12 @@ main {
     outline-offset: 2px;
   }
 
+  img,
+  video {
+    max-width: 100%;
+    height: auto;
+  }
+
   details {
     border: none;
     border-left: solid 1px var(--color-line);


### PR DESCRIPTION
## Why

Videos could render wider than the content column.

## How

Constrain body media to the container so oversized videos shrink to the available content width.

## Before / After

| Before | After |
| --- | --- |
| ![Before](https://gist.githubusercontent.com/scarf005/2d697f1adff581539f6c1d88b08df4f5/raw/707d3988de97e29a0bc44ab42ee4ba233a4a841a/before-video-full-page.svg) | ![After](https://gist.githubusercontent.com/scarf005/2d697f1adff581539f6c1d88b08df4f5/raw/a02ae760d924e12ae093b9019c9f44a158551326/after-video-full-page.svg) |

