### PR TITLE
fix: show foldable ToC on mobile

### DIFF
--- a/src/_includes/layout.vto
+++ b/src/_includes/layout.vto
@@ -75,30 +75,57 @@
       {{ include "templates/menu.vto" }}
 
       {{ if toc?.length }}
-        <nav class="toc">
-          <h2>On this page</h2>
-          <ol>
-            {{ for item of toc }}
-              <li>
-                <a href="#{{ item.slug }}">{{ item.text }}</a>
+        <nav class="toc" aria-label="On this page">
+          <details class="toc-details" open>
+            <summary>On this page</summary>
+            <ol>
+              {{ for item of toc }}
+                <li>
+                  <a href="#{{ item.slug }}">{{ item.text }}</a>
 
-                {{ if item.children.length }}
-                  <ul>
-                    {{ for child of item.children }}
-                      <li>
-                        <a href="#{{ child.slug }}">{{ child.text }}</a>
-                      </li>
-                    {{ /for }}
-                  </ul>
-                {{ /if }}
-              </li>
-            {{ /for }}
-          </ol>
+                  {{ if item.children.length }}
+                    <ul>
+                      {{ for child of item.children }}
+                        <li>
+                          <a href="#{{ child.slug }}">{{ child.text }}</a>
+                        </li>
+                      {{ /for }}
+                    </ul>
+                  {{ /if }}
+                </li>
+              {{ /for }}
+            </ol>
+          </details>
         </nav>
       {{ /if }}
 
       <main class="main">
         {{ include "templates/breadcrumb.vto" }}
+
+        {{ if toc?.length }}
+          <nav class="toc" aria-label="On this page">
+            <details class="toc-details">
+              <summary>On this page</summary>
+              <ol>
+                {{ for item of toc }}
+                  <li>
+                    <a href="#{{ item.slug }}">{{ item.text }}</a>
+
+                    {{ if item.children.length }}
+                      <ul>
+                        {{ for child of item.children }}
+                          <li>
+                            <a href="#{{ child.slug }}">{{ child.text }}</a>
+                          </li>
+                        {{ /for }}
+                      </ul>
+                    {{ /if }}
+                  </li>
+                {{ /for }}
+              </ol>
+            </details>
+          </nav>
+        {{ /if }}
 
         <div
           class="body"

--- a/src/styles.css
+++ b/src/styles.css
@@ -18,10 +18,11 @@ html {
   row-gap: 2em;
   column-gap: min(5vw, 4rem);
   grid-template-columns: 0 minmax(0, 800px) 0;
-  grid-template-rows: auto auto 1fr;
+  grid-template-rows: auto auto auto 1fr;
   grid-template-areas:
     "menu . ."
     "menu toolbar ."
+    "menu toc ."
     "menu main ."
     "menu footer ."
     "menu nav ."
@@ -42,12 +43,10 @@ html {
   }
 }
 .container > .toc {
-  display: none;
   grid-area: toc;
   overscroll-behavior: contain;
 
   @media (min-width: 1200px) {
-    display: block;
     position: sticky;
     align-self: start;
     top: 2rem;

--- a/src/styles.css
+++ b/src/styles.css
@@ -18,11 +18,10 @@ html {
   row-gap: 2em;
   column-gap: min(5vw, 4rem);
   grid-template-columns: 0 minmax(0, 800px) 0;
-  grid-template-rows: auto auto auto 1fr;
+  grid-template-rows: auto auto 1fr;
   grid-template-areas:
     "menu . ."
     "menu toolbar ."
-    "menu toc ."
     "menu main ."
     "menu footer ."
     "menu nav ."
@@ -42,11 +41,51 @@ html {
       "menu menu . .";
   }
 }
-.container > .toc {
-  grid-area: toc;
+.toc {
   overscroll-behavior: contain;
 
+  .toc-details {
+    border: 0;
+    margin: 0;
+    padding: 0;
+  }
+
+  summary {
+    --marker-image: url('data:image/svg+xml;charset=utf8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="black" viewBox="0 0 256 256"><path d="M216.49,104.49l-80,80a12,12,0,0,1-17,0l-80-80a12,12,0,0,1,17-17L128,159l71.51-71.52a12,12,0,0,1,17,17Z"></path></svg>');
+    background: none;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    font: var(--font-ui-bold);
+    padding: 0;
+    text-transform: uppercase;
+    width: fit-content;
+
+    &::before {
+      content: "";
+      display: inline-block;
+      flex: 0 0 auto;
+      width: 14px;
+      height: 14px;
+      margin-right: 0.5rem;
+      background: var(--marker-image);
+      background-size: contain;
+      transition: transform var(--animation-duration);
+    }
+  }
+  summary::-webkit-details-marker {
+    display: none;
+  }
+  .toc-details:not([open]) summary::before {
+    transform: rotate(-90deg);
+  }
+}
+.container > .toc {
+  display: none;
+  grid-area: toc;
+
   @media (min-width: 1200px) {
+    display: block;
     position: sticky;
     align-self: start;
     top: 2rem;
@@ -54,6 +93,27 @@ html {
     overflow-y: auto;
     scrollbar-width: thin;
     scrollbar-color: var(--color-dim) var(--color-background);
+
+    summary {
+      cursor: default;
+      list-style: none;
+      pointer-events: none;
+    }
+    summary::before {
+      display: none;
+    }
+  }
+}
+.main > .toc {
+  margin: var(--row-gap-xsmall) 0 2em;
+
+  @media (min-width: 1200px) {
+    display: none;
+  }
+}
+[data-theme="dark"] {
+  .toc summary {
+    --marker-image: url('data:image/svg+xml;charset=utf8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="white" viewBox="0 0 256 256"><path d="M216.49,104.49l-80,80a12,12,0,0,1-17,0l-80-80a12,12,0,0,1,17-17L128,159l71.51-71.52a12,12,0,0,1,17,17Z"></path></svg>');
   }
 }
 .container > .menu-container {

--- a/src/styles.css
+++ b/src/styles.css
@@ -105,7 +105,11 @@ html {
   }
 }
 .main > .toc {
-  margin: var(--row-gap-xsmall) 0 2em;
+  margin: var(--row-gap-xsmall) 0;
+
+  &:has(.toc-details[open]) {
+    margin-bottom: 2em;
+  }
 
   @media (min-width: 1200px) {
     display: none;


### PR DESCRIPTION
## Why

<img width="582" height="268" alt="image" src="https://github.com/user-attachments/assets/c938cae0-52a8-43ba-8fa4-237065e8fa96" />
<img width="582" height="79" alt="image" src="https://github.com/user-attachments/assets/8d0b2f04-cda4-4354-be50-92c5948651d4" />
<img width="582" height="363" alt="image" src="https://github.com/user-attachments/assets/51a13b48-079e-4ad7-968a-666064579a32" />

it's hard to navigate without table of contents in long pages.

## Testing

| Mobile, folded | Mobile, open |
| - | - |
| ![Mobile folded ToC](https://raw.githubusercontent.com/scarf005/theme-simple-wiki/401981d04d94a8c7d981199e04a1906e27f76835/mobile-collapsed.png) | ![Mobile open ToC](https://raw.githubusercontent.com/scarf005/theme-simple-wiki/401981d04d94a8c7d981199e04a1906e27f76835/mobile-expanded.png) |

Desktop sidebar:

![Desktop sidebar ToC](https://raw.githubusercontent.com/scarf005/theme-simple-wiki/401981d04d94a8c7d981199e04a1906e27f76835/desktop-sidebar.png)

<sub>PR opened by gpt-5.5 high on pi</sub>

